### PR TITLE
Avoid offline prompt even if params are not given

### DIFF
--- a/lib/sbsm/cgi.rb
+++ b/lib/sbsm/cgi.rb
@@ -27,6 +27,21 @@ require 'cgi'
 require 'drb/drb'
 
 class CGI
+  # Lets satisfy cgi-offline prompt, even if request does not have
+  # REQUEST_METHOD. (It must be mostly for test purpose).
+  # See http://ruby-doc.org/stdlib-2.3.1/libdoc/cgi/rdoc/CGI.html#method-c-new
+  def self.initialize_without_offline_prompt(*args)
+    cgi_input = true
+    unless ENV.has_key?('REQUEST_METHOD')
+      cgi_input = false
+      ENV['REQUEST_METHOD'] = 'GET'
+    end
+    cgi = CGI.new(*args)
+    unless cgi_input
+      ENV.delete('REQUEST_METHOD')
+    end
+    cgi
+  end
 	module TagMaker
     def nOE_element_def(element, append = nil)
       s = <<-END

--- a/lib/sbsm/request.rb
+++ b/lib/sbsm/request.rb
@@ -38,7 +38,7 @@ module SBSM
     include DRbUndumped
     attr_reader :cgi
     def initialize(drb_uri, html_version = "html4", cgiclass = CGI)
-      @cgi = cgiclass.new(html_version)
+      @cgi = CGI.initialize_without_offline_prompt('html4')
 			@drb_uri = drb_uri
 			@thread = nil
 			@request = Apache.request

--- a/lib/sbsm/session.rb
+++ b/lib/sbsm/session.rb
@@ -36,7 +36,7 @@ require 'delegate'
 module SBSM
   class	Session < SimpleDelegator
 		attr_reader :user, :active_thread, :app, :key, :cookie_input,
-			:unsafe_input, :valid_input, :request_path
+			:unsafe_input, :valid_input, :request_path, :cgi
 		include DRbUndumped
 		PERSISTENT_COOKIE_NAME = "sbsm-persistent-cookie"
 		DEFAULT_FLAVOR = 'sbsm'
@@ -50,7 +50,6 @@ module SBSM
 		CAP_MAX_THRESHOLD = 8
 		MAX_STATES = 4
 		SERVER_NAME = nil
-		@@cgi = CGI.new('html4')
     def Session.reset_stats
       @@stats = {}
     end
@@ -100,8 +99,7 @@ module SBSM
 			@unknown_user_class = @user.class
 			@variables = {}
       @mutex = Mutex.new
-		  #ARGV.push('') # satisfy cgi-offline prompt
-      #@cgi = CGI.new('html4')
+      @cgi = CGI.initialize_without_offline_prompt('html4')
 			super(app)
     end
     def age(now=Time.now)
@@ -132,9 +130,6 @@ module SBSM
 			@active_thread = nil
 			true
 		end
-    def cgi
-      @@cgi
-    end
     @@msie_ptrn = /MSIE/
     @@win_ptrn = /Win/i
 		def client_activex?
@@ -444,7 +439,7 @@ module SBSM
       self
     end
 		def to_html
-			@state.to_html(@@cgi)
+			@state.to_html(cgi)
     rescue DRb::DRbConnError
       raise
 		rescue StandardError => err


### PR DESCRIPTION
- Remove ARGV violation, use temporary assignment to REQUEST_METHOD
- Remove unnecessary class variable `@@cgi` in session
